### PR TITLE
update package.json to direct Jest to use the ts-jest preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
     "babel-jest": "^25.1.0",
     "jest": "^25.1.0",
     "ts-jest": "^25.2.1"
+  },
+  "jest": {
+    "preset": "ts-jest"
   }
 }


### PR DESCRIPTION
adding this will: update package.json. 

Under the current Jenkins paradigm our tests pass with a warning. When we move to new-Jenkins our tests fail because the jest tests are not converted to .js from .ts. This is a common problem with Jest and one of the higher upvoted solutions is to add the Jest preset config to package.json in an effort to have the files converted earlier in the process. 