### PR TITLE
github issue recommends adding allowJs:true to the tsconfig file

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "allowJs": true,
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "sourceMap": true,


### PR DESCRIPTION
adding this will: allow js files in the typescript config. This is another suggestion for resolving the issue in Docker where the tests fail to run because of import statements in a ts file. 