### PR TITLE
updating jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  preset: 'ts-jest',
+  preset: './node_modules/ts-jest/presets/js-with-ts',
   testEnvironment: 'node',
 };


### PR DESCRIPTION
adding this will: update the jest config to explicitly traverse node modules to the js-with-ts preset.

Jest documentation states that it will look in the dir given in the preset option for a jest-preset.js file. It is not specific about whether the preset file needs to be in the referenced directory or if it will search said directory for the file. 