### PR TITLE
trying to add ignore patterns again

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  transformIgnorePatterns: ['./node_modules/']
 };


### PR DESCRIPTION
adding this will: add transformIgnorePatterns to jest.config

with a babel.config file Jest is supposed to ignore node_modules by default, and the docs say the default transform {"\\.[jt]sx?$": "babel-jest"}  So it makes no sense that the error I'm consistently getting is that the file types are not transformed. The error suggests adding transformIgnorePatterns to ignore some/all node modules, and that's the suggestion in a github issue for Jest with Vue. 

