### PR TITLE
changing number check in findDocuments

### DIFF
--- a/util/mongo_routines.ts
+++ b/util/mongo_routines.ts
@@ -28,7 +28,7 @@ export async function findDocuments(database, collectionName, callback, query?, 
                 if (formattedQuery[queryKey] === 'true') {
                     formattedQuery[queryKey] = true;
                 }
-                if (parseInt(formattedQuery[queryKey], 10)) {
+                if (typeof formattedQuery[queryKey] === 'number') {
                     formattedQuery[queryKey] = parseInt(formattedQuery[queryKey], 10);
                 }
             }


### PR DESCRIPTION
Strings that started with a number were getting truncated into numbers. For example id: 1234asdfer2d2d567kl was getting shortened to 1234 so changed parseInt to a typeof check instead. 