### PR TITLE
separating logic to instantiate a mongo client

### DIFF
--- a/util/mongoClient.ts
+++ b/util/mongoClient.ts
@@ -1,0 +1,18 @@
+const { MongoClient } = require('mongodb');
+
+export class MongoHelper {
+    static client: any;
+
+    constructor() {
+    }
+
+    static async connect() {
+        const mongoUri = require('../dbConfig.json').mongoUri;
+        MongoHelper.client = new MongoClient(mongoUri);
+        await MongoHelper.client.connect();
+    }
+
+    async disconnect() {
+        await MongoHelper.client.close();
+    }
+}

--- a/util/mongo_routines.ts
+++ b/util/mongo_routines.ts
@@ -9,7 +9,7 @@ MongoHelper.connect();
 
 export async function findDocuments(database, collectionName, callback, query?, bodyQuery?, bodyOptions?) {
     try {
-        const db = MongoHelper.client.db(mongoDbName);
+        const db = MongoHelper.client.db(database);
         const collection = db.collection(collectionName);
 
         if (!bodyOptions) {

--- a/util/mongo_routines.ts
+++ b/util/mongo_routines.ts
@@ -1,16 +1,15 @@
-const { MongoClient } = require('mongodb');
 import { cloneDeep } from 'lodash';
+import { MongoHelper } from './mongoClient';
 const ObjectId = require('mongodb').ObjectID;
 
 const mongoUri = require('../dbConfig.json').mongoUri;
 const mongoDbName = 'lookupsdb';
 
+MongoHelper.connect();
+
 export async function findDocuments(database, collectionName, callback, query?, bodyQuery?, bodyOptions?) {
     try {
-        const mongoClient = new MongoClient(mongoUri);
-        await mongoClient.connect()
-        const db = mongoClient.db(database)
-
+        const db = MongoHelper.client.db(mongoDbName);
         const collection = db.collection(collectionName);
 
         if (!bodyOptions) {
@@ -21,7 +20,6 @@ export async function findDocuments(database, collectionName, callback, query?, 
             await collection.find(bodyQuery, bodyOptions).toArray(function(err, docs) {
                 callback(docs)
             });
-            await mongoClient.close();
         } else {
             let formattedQuery = cloneDeep(query);
             for (const queryKey of Object.keys(formattedQuery) ) {
@@ -36,7 +34,6 @@ export async function findDocuments(database, collectionName, callback, query?, 
             await collection.find(formattedQuery).toArray(function(err, docs) {
                 callback(docs)
             });
-            await mongoClient.close();
         }
     } catch(err) {
         console.error(err);
@@ -45,16 +42,12 @@ export async function findDocuments(database, collectionName, callback, query?, 
 
 export async function aggregate(database, collectionName, callback, pipeline) {
     try {
-        const mongoClient = new MongoClient(mongoUri);
-        await mongoClient.connect()
-        const db = mongoClient.db(database)
-
+        const db = MongoHelper.client.db(database);
         const collection = db.collection(collectionName);
 
         await collection.aggregate(pipeline).toArray(function(err, docs) {
             callback(docs)
         });
-        await mongoClient.close();
     } catch(err) {
         console.error(err);
     }
@@ -62,15 +55,12 @@ export async function aggregate(database, collectionName, callback, pipeline) {
 
 export async function getDocById(database, collectionName, callback, id) {
     try {
-        const mongoClient = new MongoClient(mongoUri);
-        await mongoClient.connect()
-        const db = mongoClient.db(database)
-
+        const db = MongoHelper.client.db(database);
         const collection = db.collection(collectionName);
+
         const queryId = new ObjectId(id)
         const docs = await collection.findOne({_id: queryId});
         callback(docs);
-        await mongoClient.close();
 
     } catch(err) {
         console.error(err);
@@ -79,11 +69,9 @@ export async function getDocById(database, collectionName, callback, id) {
 
 export async function getDocsById(database, collectionName, callback, ids) {
     try {
-        const mongoClient = new MongoClient(mongoUri);
-        await mongoClient.connect()
-        const db = mongoClient.db(database)
-
+        const db = MongoHelper.client.db(database);
         const collection = db.collection(collectionName);
+
         let queryIds = [];
         for (const id of ids) {
             const queryId = new ObjectId(id);
@@ -92,7 +80,6 @@ export async function getDocsById(database, collectionName, callback, ids) {
         await collection.find({"$or": queryIds }).toArray(function(err, docs) {
             callback(docs)
         });
-        await mongoClient.close();
 
     } catch(err) {
         console.error(err);
@@ -101,17 +88,14 @@ export async function getDocsById(database, collectionName, callback, ids) {
 
 export async function writeDocuments(collectionName, documents, callback) {
     try {
-        const mongoClient = new MongoClient(mongoUri);
-        await mongoClient.connect()
-        const db = mongoClient.db(mongoDbName)
-
+        const db = MongoHelper.client.db(mongoDbName);
         const collection = db.collection(collectionName);
+
         // Insert some documents
         await collection.insertMany(documents, function(err, result) {
           console.log("Inserted document into the collection");
           callback(result);
         });
-        await mongoClient.close();
     } catch(err) {
         console.error(err);
     }
@@ -119,11 +103,9 @@ export async function writeDocuments(collectionName, documents, callback) {
 
 export async function updateDocument(collectionName, document) {
     try {
-        const mongoClient = new MongoClient(mongoUri);
-        await mongoClient.connect()
-        const db = mongoClient.db(mongoDbName)
-
+        const db = MongoHelper.client.db(mongoDbName);
         const collection = db.collection(collectionName);
+
         const result = await collection.findOneAndUpdate(
             {_id: document._id},
             {
@@ -133,7 +115,6 @@ export async function updateDocument(collectionName, document) {
                 upsert: true
             }
         )
-        await mongoClient.close();
         return result;
     } catch(err) {
         console.error(err);
@@ -142,15 +123,12 @@ export async function updateDocument(collectionName, document) {
 
 export async function deleteDocument(collectionName, document) {
     try {
-        const mongoClient = new MongoClient(mongoUri);
-        await mongoClient.connect()
-        const db = mongoClient.db(mongoDbName)
-
+        const db = MongoHelper.client.db(mongoDbName);
         const collection = db.collection(collectionName);
+
         const result = await collection.deleteOne(
             {_id: document._id}
         )
-        await mongoClient.close();
         return result;
     } catch(err) {
         console.error(err);


### PR DESCRIPTION
When instantiating a mongo client, a pool of connections are created. These connections are reused and are returned to the pool after use so there is no need to create a connection then close one. Also, it's very expensive to create and close connections as detailed in these posts below. 

https://www.mongodb.com/community/forums/t/where-to-close-db-connection/1368
https://stackoverflow.com/questions/52067945/when-to-close-a-mongodb-connection

